### PR TITLE
Group downloaded files into sub-directories based on the files' timestamps

### DIFF
--- a/src/downloader/placement-strategy.ts
+++ b/src/downloader/placement-strategy.ts
@@ -1,0 +1,28 @@
+import * as fs from "node:fs/promises";
+import path from "node:path";
+
+export interface TargetPlacementStrategy {
+    resolveTargetPath(sourcePath: string): Promise<string>;
+}
+
+export class GroupByDatePlacementStrategy implements TargetPlacementStrategy {
+    public constructor(private readonly root: string) {}
+
+    public async resolveTargetPath(sourcePath: string): Promise<string> {
+        const modifiedAt = (await fs.stat(sourcePath)).mtime;
+        const sourceFileName = path.basename(sourcePath);
+
+        return `${this.root}/${this.formatDate(modifiedAt)}/${sourceFileName}`;
+    }
+
+    private formatDate(date: Date) {
+        // TODO: support configuring the date format.
+        return (
+            `${date.getFullYear()}` +
+            "-" +
+            `${date.getMonth() + 1}`.padStart(2, "0") +
+            "-" +
+            `${date.getDate()}`.padStart(2, "0")
+        );
+    }
+}

--- a/test/downloader/placement-strategy.spec.ts
+++ b/test/downloader/placement-strategy.spec.ts
@@ -1,0 +1,35 @@
+import { Stats } from "node:fs";
+import * as fs from "node:fs/promises";
+import { GroupByDatePlacementStrategy } from "../../src/downloader/placement-strategy";
+
+jest.mock("node:fs/promises");
+
+describe("GroupByDatePlacementStrategy", () => {
+    const strategy = new GroupByDatePlacementStrategy("/tmp/dummy-root-dir");
+
+    function composeTestCase(modifiedAt: Date, expectedTargetFilePath: string) {
+        describe(`Given file last modified at ${modifiedAt}`, () => {
+            const sourceFilePath = "/tmp/dummy-source/test-file-a.txt";
+
+            it(`Expect ${expectedTargetFilePath}`, async () => {
+                jest.mocked(fs.stat).mockResolvedValue({ mtime: modifiedAt } as Stats);
+
+                const actual = await strategy.resolveTargetPath(sourceFilePath);
+
+                expect(actual).toStrictEqual(expectedTargetFilePath);
+
+                expect(fs.stat).toHaveBeenCalledTimes(1);
+                expect(fs.stat).toHaveBeenCalledWith(sourceFilePath);
+            });
+        });
+    }
+
+    composeTestCase(new Date(2020, 5 /*June*/, 17), "/tmp/dummy-root-dir/2020-06-17/test-file-a.txt");
+    composeTestCase(new Date(2020, 5 /*June*/, 17, 23, 59), "/tmp/dummy-root-dir/2020-06-17/test-file-a.txt");
+
+    composeTestCase(new Date(2020, 9 /*Oct*/, 17), "/tmp/dummy-root-dir/2020-10-17/test-file-a.txt");
+    composeTestCase(new Date(2020, 9 /*Oct*/, 17, 23, 47, 34), "/tmp/dummy-root-dir/2020-10-17/test-file-a.txt");
+
+    composeTestCase(new Date(1985, 9 /*Oct*/, 17), "/tmp/dummy-root-dir/1985-10-17/test-file-a.txt");
+    composeTestCase(new Date(2045, 9 /*Oct*/, 17), "/tmp/dummy-root-dir/2045-10-17/test-file-a.txt");
+});


### PR DESCRIPTION
1. Add a new `TargetPlacementStrategy` interface with a single `resolveTargetPath` method
   and a `GroupByDatePlacementStrategy` class implementing that method
   by combining the configured target root path, an intermediate directory name derived from the source file's timestamp
   and the source file's basename.
2. Update the `Downloader.downloadNewFilesFromDir` method to resolve a `TargetPlacementStrategy`
   for the current directory download configuration and then use it
   to determine the full target path for each file that needs to be copied from the current source directory.

### Testing
```bash
npm run build && npm run lint && npm run test
```

**AR == ER**: all is successful.

File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s     
-------------------------------|---------|----------|---------|---------|-----------------------
All files                      |   74.57 |    88.63 |    82.6 |   74.57 |                       
 src                           |       0 |        0 |       0 |       0 |                       
  index.ts                     |       0 |        0 |       0 |       0 | 1-5                   
 src/downloader                |   46.92 |    70.58 |   66.66 |   46.92 |                       
  configuration.ts             |   84.84 |    72.72 |   66.66 |   84.84 | 27-28,50-51,61-66    
  downloader.ts                |       0 |        0 |       0 |       0 | 1-84
  index.ts                     |       0 |        0 |       0 |       0 | 1
  placement-strategy.ts        |     100 |      100 |     100 |     100 | 
 src/scanner                   |   89.53 |    93.18 |     100 |   89.53 | 
  index.ts                     |     100 |      100 |     100 |     100 | 
  sequential-naming-scanner.ts |   89.47 |    93.02 |     100 |   89.47 | 73-79,111-116,163-167
 src/source-cursor             |   95.12 |       75 |     100 |   95.12 | 
  index.ts                     |   95.12 |       75 |     100 |   95.12 | 30-31
 src/utils                     |     100 |      100 |     100 |     100 | 
  arrays.ts                    |     100 |      100 |     100 |     100 | 
  path.ts                      |     100 |      100 |     100 |     100 | 
  string.ts                    |     100 |      100 |     100 |     100 | 

```
Test Suites: 4 passed, 4 total
Tests:       18 passed, 18 total
Snapshots:   0 total
Time:        5.689 s
Ran all test suites.
```