### PR TITLE
Update the draft `Downloader` implementation to actually download discovered new files

### DIFF
--- a/src/downloader/file-copier.ts
+++ b/src/downloader/file-copier.ts
@@ -1,0 +1,39 @@
+import * as fs from "node:fs/promises";
+import path from "node:path";
+
+export class FileCopier {
+    private readonly createdDirsCache: Set<string> = new Set();
+
+    public constructor(private readonly handlers: FileCopyEventsHandler = {}) {}
+
+    public async copy(sourceFile: string, targetFile: string) {
+        const targetDir = path.dirname(targetFile);
+        if (!this.createdDirsCache.has(targetDir)) {
+            await fs.mkdir(targetDir, { recursive: true });
+            this.createdDirsCache.add(targetDir);
+        }
+
+        try {
+            await fs.copyFile(sourceFile, targetFile, fs.constants.COPYFILE_EXCL);
+        } catch (e) {
+            if ((e as NodeJS.ErrnoException)?.code === "EEXIST" && !!this.handlers?.onTargetAlreadyExists) {
+                const result = await this.handlers.onTargetAlreadyExists(sourceFile, targetFile);
+                if (result.action === "overwrite") {
+                    await fs.copyFile(sourceFile, targetFile);
+                } else if (result.action === "rename") {
+                    await this.copy(sourceFile, result.to);
+                }
+            } else {
+                throw e;
+            }
+        }
+    }
+}
+
+export type OnTargetAlreadyExistsAction =
+    | { readonly action: "overwrite" | "skip" }
+    | { readonly action: "rename"; readonly to: string };
+
+export type FileCopyEventsHandler = {
+    onTargetAlreadyExists?: (sourceFile: string, targetFile: string) => Promise<OnTargetAlreadyExistsAction>;
+};

--- a/test/downloader/.resources/dummy-drive-2/DCIM/IMG001.ARW
+++ b/test/downloader/.resources/dummy-drive-2/DCIM/IMG001.ARW
@@ -1,0 +1,1 @@
+Test file content

--- a/test/downloader/file-copier.spec.ts
+++ b/test/downloader/file-copier.spec.ts
@@ -1,0 +1,117 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import { FileCopier } from "../../src/downloader/file-copier";
+
+jest.mock("node:fs/promises");
+
+const realFs: typeof fs = jest.requireActual("node:fs/promises");
+
+describe("FileCopier", () => {
+    describe("Given a single file to copy", () => {
+        const sourceFile = `${__dirname}/.resources/dummy-drive-2/DCIM/IMG001.ARW`;
+
+        async function createTestTarget() {
+            const targetRoot = await realFs.mkdtemp(`${os.tmpdir()}/dummy-target-`);
+
+            const targetFileDir = `${targetRoot}/subdir01`;
+            const targetFile = `${targetFileDir}/IMG001.ARW`;
+
+            return { targetRoot, targetFileDir, targetFile };
+        }
+
+        function replaceFsMocksWithSpies() {
+            const mkdir = jest.mocked(fs.mkdir);
+            mkdir.mockImplementation(realFs.mkdir);
+            const copyFile = jest.mocked(fs.copyFile);
+            copyFile.mockImplementation(realFs.copyFile);
+
+            return { mkdir, copyFile };
+        }
+
+        describe("And the target directory does not exist", () => {
+            it("Should create the target directory and copy the file", async () => {
+                const { mkdir, copyFile } = replaceFsMocksWithSpies();
+
+                const { targetFileDir, targetFile } = await createTestTarget();
+
+                const copier = new FileCopier();
+
+                await copier.copy(sourceFile, targetFile);
+
+                expect(mkdir).toHaveBeenCalledWith(targetFileDir, { recursive: true });
+                expect(copyFile).toHaveBeenCalledWith(sourceFile, targetFile, fs.constants.COPYFILE_EXCL);
+            });
+        });
+
+        describe("And the target directory already exists", () => {
+            describe("When attempting to create the target directory", () => {
+                it("Should not fail", async () => {
+                    const { mkdir, copyFile } = replaceFsMocksWithSpies();
+
+                    const { targetFileDir, targetFile } = await createTestTarget();
+                    await realFs.mkdir(targetFileDir);
+
+                    const copier = new FileCopier();
+
+                    await copier.copy(sourceFile, targetFile);
+
+                    // Verify that `FileCopier` attempted to create the directory anyway.
+                    expect(mkdir).toHaveBeenCalledWith(targetFileDir, { recursive: true });
+                    expect(copyFile).toHaveBeenCalledWith(sourceFile, targetFile, fs.constants.COPYFILE_EXCL);
+                });
+            });
+        });
+
+        describe("And the target file already exists", () => {
+            describe("And copy events handler is not provided", () => {
+                it("Should refuse", async () => {
+                    const { copyFile } = replaceFsMocksWithSpies();
+
+                    const copier = new FileCopier();
+
+                    const { targetFileDir, targetFile } = await createTestTarget();
+                    await realFs.mkdir(targetFileDir);
+                    await realFs.writeFile(targetFile, "Original test file content");
+
+                    await expect(() => copier.copy(sourceFile, targetFile)).rejects.toThrow(/.?file already exists.?/);
+
+                    expect(copyFile).toHaveBeenCalledWith(sourceFile, targetFile, fs.constants.COPYFILE_EXCL);
+                    // Verify that the file was not corrupted despite making the `fs.copyFile` unconditionally.
+                    expect(await realFs.readFile(targetFile, { encoding: "utf8" })).toStrictEqual(
+                        "Original test file content"
+                    );
+                });
+            });
+        });
+    });
+
+    describe("Given multiple requests to copy files", () => {
+        it("Should create each target directory once", async () => {
+            const mockMkdir = jest.mocked(fs.mkdir);
+
+            const copier = new FileCopier();
+
+            await copier.copy("/tmp/dummy-file-1", "/tmp/dummy-target/dir01/file01");
+            await copier.copy("/tmp/dummy-file-2", "/tmp/dummy-target/dir01/file02");
+            await copier.copy("/tmp/dummy-file-3", "/tmp/dummy-target/dir01/file03");
+
+            expect(mockMkdir.mock.calls).toStrictEqual([["/tmp/dummy-target/dir01", { recursive: true }]]);
+
+            await copier.copy("/tmp/dummy-file-4", "/tmp/dummy-target/dir02/file04");
+
+            expect(mockMkdir.mock.calls).toStrictEqual([
+                ["/tmp/dummy-target/dir01", { recursive: true }],
+                ["/tmp/dummy-target/dir02", { recursive: true }],
+            ]);
+
+            await copier.copy("/tmp/dummy-file-5", "/tmp/dummy-target/dir03/file05");
+            await copier.copy("/tmp/dummy-file-6", "/tmp/dummy-target/dir03/file06");
+
+            expect(mockMkdir.mock.calls).toStrictEqual([
+                ["/tmp/dummy-target/dir01", { recursive: true }],
+                ["/tmp/dummy-target/dir02", { recursive: true }],
+                ["/tmp/dummy-target/dir03", { recursive: true }],
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
1. Add a new `FileCopier` class with a `copy` method encapsulating the logic to:
    - automatically create necessary directories at the destination
    - actually attempt copying the file
    - identify and handle the edge case when the specified target file already exists
      using a provided `FileCopyEventsHandler` implementation
2. Update the `Downloader` class to:
    1. Create and configure a `FileCopier` instance with a simple `FileCopyEventsHandler` implementation
       to automatically skip copying over existing files.
    2. Update the `downloadNewFilesFromDir` method to call the `FileCopier.copy` method
       from the `newFiles` loop.

### Manual Test
#### in addition to running unit tests added by this PR
1.  Manually create `%USER_DR%\AppData\Local\auto-download\config.json` with the following content.

    ```json
    {
        "DCIM": {
            "target": {
                "root": "%MY_PHOTOS%"
            }
        }
    }
    ```

1.  Create a cursor file: `X:\DCIM\.auto-download\cursor.json`:

    ```json
    {"sequential":{"lastProcessedFile":"101MSDCF/%LAST_FILE_I_COPIED_MANUALLY%"}}
    ```

1.  Manually copy one of the newer files from my memory card to an appropriately named new directory.

1.  Temporarily put the following code into the `index.ts`:

    ```typescript
    import { Downloader } from "./downloader";

    (async function () {
        new Downloader().downloadAllNewFiles("X:");
    })();
    ```

1.  Build and run the main script:

    ```bash
    npm run build && node dist/index.js
    ```

    - **AR == ER**: the script is executed successfully.
    - **AR == ER**: the script found and copied new files from my memory card.
    - **AR == ER**: the script automatically skipped the file I already copied manually.

    ```
    [X:] Found 1 supported directory: X:/DCIM
    [X:/DCIM] Skip previously processed sub-directories and/or files: 100MSDCF
    [X:/DCIM] 101MSDCF is the latest previously processed sub-directory and could have new files: will process all sub-directories and files starting from it: 101MSDCF
    [X:/DCIM/101MSDCF] Skip previously processed sub-directories and/or files: --redacted--
    [X:/DCIM/101MSDCF] New sub-directories and/or files found: --redacted--
    [X:/DCIM] Found 20 new files in total (in this source directory)
    [X:/DCIM] Copy 101MSDCF/--redacted-- to %MY_PHOTOS%/2023-10-27/--redacted--
    ...
    --redacted-- already exists in %MY_PHOTOS%/2023-11-12: skip copying X:/DCIM/101MSDCF/--redacted--
    ...
    [X:/DCIM] Save final cursor position: 101MSDCF/--redacted--
    ```