### PR TITLE
Use progress bar to show the progress of copying files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,14 @@
       "name": "memcard-autoupload",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "cli-progress": "^3.12.0"
+      },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.2",
         "@types/chai": "^4.3.9",
         "@types/chai-as-promised": "^7.1.8",
+        "@types/cli-progress": "^3.11.5",
         "@types/jest": "^29.5.8",
         "@types/node": "^20.8.10",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
@@ -1518,6 +1522,15 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.5.tgz",
+      "integrity": "sha512-D4PbNRbviKyppS5ivBGyFO29POlySLmA2HyUFE4p5QGazAMM3CwkKWcvTl8gvElSuxRh6FPKL8XmidX873ou4g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1875,7 +1888,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2283,6 +2295,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-progress/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/cli-progress/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-truncate": {
@@ -5260,7 +5309,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tsconfig/node20": "^20.1.2",
     "@types/chai": "^4.3.9",
     "@types/chai-as-promised": "^7.1.8",
+    "@types/cli-progress": "^3.11.5",
     "@types/jest": "^29.5.8",
     "@types/node": "^20.8.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
@@ -47,5 +48,8 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
+  },
+  "dependencies": {
+    "cli-progress": "^3.12.0"
   }
 }

--- a/src/downloader/progress.ts
+++ b/src/downloader/progress.ts
@@ -1,0 +1,63 @@
+import { MultiBar, Presets, SingleBar } from "cli-progress";
+
+export class ProgressTracker {
+    private readonly multiBar: MultiBar;
+
+    constructor() {
+        this.multiBar = new MultiBar(
+            {
+                format: "[{sourceDir}] Downloading new files {bar} {percentage}% | {value}/{total} | Speed: {speed} | {summary}",
+                barCompleteChar: "\u2588",
+                barIncompleteChar: "\u2591",
+                hideCursor: true,
+            },
+            Presets.shades_grey
+        );
+    }
+
+    /**
+     * Start tracking progress of copying a new batch of files.
+     * @param sourceDir
+     * @param total total number of new files in this batch
+     * @returns new single-line progress bar
+     */
+    public startTracking(sourceDir: string, total: number): SingleDirBar {
+        return new SingleDirBar(this.multiBar.create(total, 0, { sourceDir, speed: "N/A" }));
+    }
+
+    /**
+     * Log a message above all progress bars.
+     * @param message
+     */
+    public log(message: string) {
+        this.multiBar.log(`${message}\n`);
+    }
+
+    public stop() {
+        this.multiBar.stop();
+    }
+}
+
+/**
+ * Tracks the progress of copying a given batch of files.
+ */
+export class SingleDirBar {
+    constructor(private readonly progressBar: SingleBar) {}
+
+    /**
+     * Set short summary of the current state of the overall operation progress
+     * (shown to the right of the progress bar).
+     * @param summary
+     */
+    public setStatusSummary(summary: string) {
+        this.progressBar.increment(0, { summary });
+    }
+
+    public increment() {
+        return this.progressBar.increment();
+    }
+
+    public stop() {
+        this.progressBar.stop();
+    }
+}


### PR DESCRIPTION
Fixes #11 - Use progress bar to show the progress of copying files from each recognized source directory

1. Add a new dependency on the `cli-progress` library (Npm package).
2. Add a new `ProgressTracker` and `SingleDirBar` classes
   wrapping the `MultiBar` and `SingleBar` classes from the `cli-progress` library respectively
   to encapsulate the minutia of managing a console progress bar away from the main `Downloader` class.
3. Update the `Downloader.downloadNewFilesFromDir` method:
    - use `ProgressTracker.startTracking` before starting the loop over `newFiles`
      in order to create a new progress bar to track the progress of downloading new file
      from the current source directory
    - update the progress bar state with each copied file
    - use `ProgressTracker.log` instead of `console.log` and similar methods
      in order to avoid conflicts with running progress bars
    - use `SingleDirBar.setStatusSummary` to 'log' the two `INFO` messages
      about saving source directory cursor position (aka latest processed file)
      after downloading all new files from a given source directory
      in order to show the latest of the two to the right of the associated completed progress bar

### Manual Testing
1. Using a memory card that had a few new photos since the last time I downloaded photos from it using this tool.
1. Manually update the `cursor.json` file on my memory card to roll it two files back in order to have the tool pick up the two most recently copied files as if they were new.
1. Run the tool to copy new photos: `npm run build && node dist`

   - **AR == ER**: the output now contains a progress reflecting how many files were copied (as a number and as a percentage), what file is being copied at the moment and such.
   - **AR == ER**: the two warning messages about the two files being already present in the target location are shown above the progress bar and, more importantly, do not break the progress bar like a regular `console.log` would.

   ![image](https://github.com/andreiled/memcard-autoupload/assets/2260810/1d61a15c-6ba7-4d8e-adfe-ed20101b1b38)