### PR TITLE
Basic implementation for the `init` command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "cli-progress": "^3.12.0",
-        "commander": "^11.1.0"
+        "commander": "^11.1.0",
+        "prompts": "^2.4.2"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.2",
@@ -20,6 +21,7 @@
         "@types/commander": "^2.12.2",
         "@types/jest": "^29.5.8",
         "@types/node": "^20.8.10",
+        "@types/prompts": "^2.4.9",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
         "chai": "^4.3.10",
@@ -1599,6 +1601,16 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
+      "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
       }
     },
     "node_modules/@types/semver": {
@@ -4251,7 +4263,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4888,7 +4899,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
       "dependencies": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -5164,8 +5174,7 @@
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/commander": "^2.12.2",
     "@types/jest": "^29.5.8",
     "@types/node": "^20.8.10",
+    "@types/prompts": "^2.4.9",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "chai": "^4.3.10",
@@ -52,6 +53,7 @@
   },
   "dependencies": {
     "cli-progress": "^3.12.0",
-    "commander": "^11.1.0"
+    "commander": "^11.1.0",
+    "prompts": "^2.4.2"
   }
 }

--- a/src/actions/init/index.ts
+++ b/src/actions/init/index.ts
@@ -1,0 +1,27 @@
+import prompts from "prompts";
+import { writeAutoDownloadConfiguration } from "../../configuration/serializer";
+
+export async function initAutoDownloadConfiguration() {
+    const photosTargetRootDir = await promptTargetRootDirPath(
+        "Please specify the root directory where you want all photos to go."
+    );
+
+    await writeAutoDownloadConfiguration({
+        DCIM: {
+            target: {
+                root: photosTargetRootDir,
+            },
+        },
+        // TODO: configuration for video files captured by Sony cameras.
+    });
+}
+
+async function promptTargetRootDirPath(message: string) {
+    return (
+        await prompts({
+            type: "text",
+            name: "targetRootDir",
+            message,
+        })
+    ).targetRootDir;
+}

--- a/src/configuration/serializer.ts
+++ b/src/configuration/serializer.ts
@@ -1,22 +1,35 @@
 import * as fs from "node:fs/promises";
+import path from "node:path";
 import { DriveDownloadConfiguration } from "./types";
 
 export async function readAutoDownloadConfiguration(configDir?: string): Promise<DriveDownloadConfiguration> {
     try {
-        const resolvedConfigDir = configDir ?? `${getLocalAppDataDir()}/auto-download`;
         // TODO: validate that the configuration is actually valid.
-        return JSON.parse(await fs.readFile(`${resolvedConfigDir}/config.json`, { encoding: "utf8" }));
+        return JSON.parse(await fs.readFile(resolveConfigFilePath(configDir), { encoding: "utf8" }));
     } catch (error) {
         if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
             throw new Error(
-                // TODO: specify what command to actually run once it is implemented.
-                "Auto-download configuration is missing on this computer, please run the ??? command to initialize the configuration.",
+                "Auto-download configuration is missing on this computer, please use the `init` command to initialize it.",
                 { cause: error }
             );
         } else {
             throw error;
         }
     }
+}
+
+export async function writeAutoDownloadConfiguration(config: DriveDownloadConfiguration, configDir?: string) {
+    const configFile = resolveConfigFilePath(configDir);
+
+    await fs.mkdir(path.dirname(configFile), { recursive: true });
+    await fs.writeFile(configFile, JSON.stringify(config));
+
+    console.info("Configuration written to: %s", configFile);
+}
+
+function resolveConfigFilePath(configDir?: string): string {
+    const resolvedConfigDir = configDir ?? `${getLocalAppDataDir()}/auto-download`;
+    return `${resolvedConfigDir}/config.json`;
 }
 
 function getLocalAppDataDir() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,11 @@
 import { program } from "commander";
 import { downloadAllNewFiles } from "./actions/download";
+import { initAutoDownloadConfiguration } from "./actions/init";
 
 program
     .command("init")
     .description("Initialize a global configuration")
-    .action(async () => {
-        // TODO: initialize configuration.
-        throw new Error("Not implemented yet");
-    });
+    .action(initAutoDownloadConfiguration);
 
 program
     .description(

--- a/test/actions/init/index.spec.ts
+++ b/test/actions/init/index.spec.ts
@@ -1,0 +1,35 @@
+import prompts from "prompts";
+import { initAutoDownloadConfiguration } from "../../../src/actions/init";
+import { writeAutoDownloadConfiguration } from "../../../src/configuration/serializer";
+
+jest.mock("prompts");
+jest.mock("../../../src/configuration/serializer");
+
+describe("initAutoDownloadConfiguration", () => {
+    it("Should ask the user for target locations and write a new configuration", async () => {
+        const mockPrompts = jest.mocked(prompts);
+        mockPrompts.mockResolvedValueOnce({ ["targetRootDir"]: "/home/dauser/all-my-photos" });
+
+        await initAutoDownloadConfiguration();
+
+        expect(mockPrompts).toHaveBeenCalledTimes(1);
+
+        {
+            const promptArgs = mockPrompts.mock.calls[0];
+            expect(promptArgs[0]).toHaveProperty("type", "text");
+            expect(promptArgs[0]).toHaveProperty(
+                "message",
+                "Please specify the root directory where you want all photos to go."
+            );
+        }
+
+        expect(jest.mocked(writeAutoDownloadConfiguration)).toHaveBeenCalledTimes(1);
+        expect(jest.mocked(writeAutoDownloadConfiguration)).toHaveBeenCalledWith({
+            DCIM: {
+                target: {
+                    root: "/home/dauser/all-my-photos",
+                },
+            },
+        });
+    });
+});

--- a/test/configuration/serializer.spec.ts
+++ b/test/configuration/serializer.spec.ts
@@ -1,8 +1,10 @@
-/* eslint-disable-next-line @typescript-eslint/no-var-requires */
-require("chai").use(require("chai-as-promised"));
-
-import { expect } from "chai";
-import { DriveDownloadConfiguration, readAutoDownloadConfiguration } from "../../src/configuration";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import {
+    DriveDownloadConfiguration,
+    readAutoDownloadConfiguration,
+    writeAutoDownloadConfiguration,
+} from "../../src/configuration";
 
 describe("readAutoDownloadConfiguration", () => {
     describe("Given configuration file exists in specified directory", () => {
@@ -17,17 +19,50 @@ describe("readAutoDownloadConfiguration", () => {
                 },
             };
 
-            expect(await readAutoDownloadConfiguration(`${__dirname}/.resources/valid-config-dir`)).to.be.deep.equal(
-                expected
-            );
+            expect(await readAutoDownloadConfiguration(`${__dirname}/.resources/valid-config-dir`)).toEqual(expected);
         });
     });
 
     describe("Given configuration file does not exist in specified directory", () => {
         it("Expect error", async () => {
-            expect(readAutoDownloadConfiguration(`${__dirname}/.resources/invalid-config-dir`)).to.be.rejectedWith(
-                Error,
+            expect(readAutoDownloadConfiguration(`${__dirname}/.resources/invalid-config-dir`)).rejects.toThrow(
                 /Auto-download configuration is missing on this computer.?/
+            );
+        });
+    });
+});
+
+describe("writeAutoDownloadConfiguration", () => {
+    const dummyConfig: DriveDownloadConfiguration = {
+        DCIM: {
+            target: {
+                root: "/etc/all-my-photos",
+            },
+        },
+    };
+
+    describe("Given configuration file exists in specified directory", () => {
+        it("Should overwrite the file", async () => {
+            const configDir = await fs.mkdtemp(`${os.tmpdir()}/dummy-config-dir-`);
+            await fs.writeFile(`${configDir}/config.json`, JSON.stringify({ XYZ: { target: {} } }));
+
+            await writeAutoDownloadConfiguration(dummyConfig, configDir);
+
+            expect(JSON.parse(await fs.readFile(`${configDir}/config.json`, { encoding: "utf8" }))).toEqual(
+                dummyConfig
+            );
+        });
+    });
+
+    describe("Given neither configuration directory nor configuration file exist", () => {
+        it("Should create configuration directory and write configuration to file", async () => {
+            const mockUserDir = await fs.mkdtemp(`${os.tmpdir()}/dummy-user-dir-`);
+            const configDir = `${mockUserDir}/auto-download`;
+
+            await writeAutoDownloadConfiguration(dummyConfig, configDir);
+
+            expect(JSON.parse(await fs.readFile(`${configDir}/config.json`, { encoding: "utf8" }))).toEqual(
+                dummyConfig
             );
         });
     });


### PR DESCRIPTION
1. Add a new `actions/init` module with basic logic to initialize a global auto-download configuration
   (as a starting point, only generate configuration entries required to
   download new photos from common digital cameras).

    Use `prompts` Npm package to ask user where to put downloaded files.
2. Configure the `init` command to invoke the implementation in the new
   `actions/init` module.

### Manual Testing
![image](https://github.com/andreiled/memcard-autoupload/assets/2260810/b8abe5f6-42d4-42f9-a0b7-703133f45934)
