### PR TITLE
Force flush latest log messages before stopping the progress tracker

### DIFF
--- a/src/actions/download/progress.ts
+++ b/src/actions/download/progress.ts
@@ -34,6 +34,10 @@ export class ProgressTracker {
     }
 
     public stop() {
+        // Force flush all custom log messages if they were not flushed yet.
+        // https://github.com/npkgz/cli-progress/issues/145
+        this.multiBar.update();
+
         this.multiBar.stop();
     }
 }


### PR DESCRIPTION
Update the `ProgressTracker.stop` method to call `MultiBar.update` before `MultiBar.stop` in order to force it to flush the latest accumulated log messages right away instead of waiting for the next regular update that will never come.

### Manual Testing
1.  Temporarily update `src/actions/download/downloader.ts` to use `this.progressTracker.log` instead of `progressBar.setStatusSummary` to post its final updates:

    ```
    --- a/src/actions/download/downloader.ts
    +++ b/src/actions/download/downloader.ts
    @@ -83,7 +83,7 @@ export class Downloader {
                 }

                 const lastProcessedFile = newFiles[newFiles.length - 1];
    -            progressBar.setStatusSummary(`Saving final cursor position: ${lastProcessedFile}`);
    +            this.progressTracker.log(`Saving final cursor position: ${lastProcessedFile}`);    

                 await saveDirectoryCursor(sourceDir, {
                     ...cursor,
    @@ -92,7 +92,7 @@ export class Downloader {
                         lastProcessedFile,
                     },
                 });
    -            progressBar.setStatusSummary(`Saved final cursor position: ${lastProcessedFile}`);
    +            this.progressTracker.log(`Saved final cursor position: ${lastProcessedFile}`);
                 progressBar.stop();
             } else {
                 this.progressTracker.log(`[${sourceDir}] No new files found`);
    ```

    _Note_: not making this particular change permanent since it actually makes more sense to post this final update about having saved the last processed file name to the right of the progress bar where it normally shows the current file being copied [rather than above the progress bar].

1.  Run the tool: `npm run build && node dist X:`, and review the output.

    ```
    [X:] Found 1 supported directory: X:/DCIM
    [X:/DCIM] 101MSDCF is the latest previously processed sub-directory and could have new files: will process all sub-directories and files starting from it: 101MSDCF
    [X:/DCIM/101MSDCF] Skip previously processed sub-directories and/or files: REDACTED, ..., REDACTED
    [X:/DCIM/101MSDCF] New sub-directories and/or files found: REDACTED
    [X:/DCIM] Found 3 new files in total (in this source directory)
    Saving final cursor position: 101MSDCF/REDACTED
    Saved final cursor position: 101MSDCF/REDACTED
    [X:/DCIM] Downloading new files ████████████████████████████████████████ 100% | 3/3 | Speed: N/A | 101MSDCF/REDACTED => REDACTED
    ```

    **AR == ER**: the two final updates are printed above the progress line.